### PR TITLE
feat(gui): add dedicated registration flow

### DIFF
--- a/vault_complete.py
+++ b/vault_complete.py
@@ -8,6 +8,7 @@ from vault_core import load_or_create_vault, save_vault
 from password_generator import generate_password, check_password_strength
 from cloud_sync import LocalCloudSync
 from security_audit import SecurityAudit, SecureClipboard
+from password_vault.auth import authenticate, create_user, load_user_db
 
 # Configuración de tema
 ctk.set_appearance_mode("dark")
@@ -19,6 +20,7 @@ class PasswordVaultComplete:
         self.vault_key = None
         self.vault_file = "password_vault_complete.json"
         self.master_password = None
+        self.username = None
         self.cloud_sync = LocalCloudSync("vault_cloud_complete")
         self.security_audit = SecurityAudit()
         self.secure_clipboard = SecureClipboard()
@@ -107,23 +109,37 @@ class PasswordVaultComplete:
         features_label = ctk.CTkLabel(features_frame, text=features_text, 
                                      font=ctk.CTkFont(size=12), justify="left")
         features_label.pack(pady=10)
-        
+
+        # Campo de usuario
+        self.username_entry = ctk.CTkEntry(
+            login_frame,
+            placeholder_text="Nombre de usuario",
+            width=300,
+            height=40,
+        )
+        self.username_entry.pack(pady=10)
+
         # Campo de contraseña
-        self.password_entry = ctk.CTkEntry(login_frame, placeholder_text="Contraseña maestra", 
-                                          show="*", width=300, height=40)
-        self.password_entry.pack(pady=20)
+        self.password_entry = ctk.CTkEntry(
+            login_frame,
+            placeholder_text="Contraseña",
+            show="*",
+            width=300,
+            height=40,
+        )
+        self.password_entry.pack(pady=10)
         
         # Botones de acceso
         button_frame = ctk.CTkFrame(login_frame)
         button_frame.pack(pady=10)
-        
-        login_button = ctk.CTkButton(button_frame, text="🔓 Acceder", command=self.login, 
+
+        login_button = ctk.CTkButton(button_frame, text="🔓 Acceder", command=self.login,
                                      width=150, height=40)
         login_button.pack(side="left", padx=10)
-        
-        sync_login_button = ctk.CTkButton(button_frame, text="☁️ Sincronizar y Acceder", 
-                                         command=self.sync_and_login, width=200, height=40)
-        sync_login_button.pack(side="left", padx=10)
+
+        register_button = ctk.CTkButton(button_frame, text="📝 Registrar",
+                                       command=self.register, width=150, height=40)
+        register_button.pack(side="left", padx=10)
         
         # Configuración de auto-bloqueo
         config_frame = ctk.CTkFrame(login_frame)
@@ -146,68 +162,91 @@ class PasswordVaultComplete:
         
         # Bind Enter key
         self.password_entry.bind("<Return>", lambda event: self.login())
-        self.password_entry.focus()
-        
+        self.username_entry.bind("<Return>", lambda event: self.login())
+        self.username_entry.focus()
+
+    def validate_credentials(self, username: str, password: str) -> bool:
+        """Valida que los campos de usuario y contraseña cumplan requisitos básicos."""
+        if not username or not password:
+            messagebox.showerror("Error", "Debes ingresar usuario y contraseña")
+            return False
+        if len(username) < 3 or not username.isalnum():
+            messagebox.showerror(
+                "Error", "El usuario debe tener al menos 3 caracteres alfanuméricos"
+            )
+            return False
+        if len(password) < 8:
+            messagebox.showerror(
+                "Error", "La contraseña debe tener al menos 8 caracteres"
+            )
+            return False
+        return True
+
+    def authenticate_user(self) -> bool:
+        """Valida las credenciales del usuario."""
+        username = self.username_entry.get().strip()
+        password = self.password_entry.get()
+
+        if not self.validate_credentials(username, password):
+            return False
+
+        db_file = "users.json"
+        if authenticate(username, password, db_file):
+            self.vault_file = f"{username}_vault.json"
+            self.master_password = password
+            self.username = username
+            return True
+
+        db = load_user_db(db_file)
+        if username not in db:
+            messagebox.showerror("Error", "Usuario no registrado.")
+            return False
+
+        messagebox.showerror("Error", "Contraseña incorrecta.")
+        return False
+
     def login(self):
         """Maneja el proceso de inicio de sesión normal"""
-        password = self.password_entry.get()
-        
-        if not password:
-            messagebox.showerror("Error", "Por favor ingresa tu contraseña maestra")
+        if not self.authenticate_user():
             return
-            
+
         try:
-            self.vault_data, self.vault_key = load_or_create_vault(self.vault_file, password)
-            self.master_password = password
+            self.vault_data, self.vault_key = load_or_create_vault(
+                self.vault_file, self.master_password
+            )
             self.update_activity()
             self.setup_main_screen()
         except Exception as e:
             messagebox.showerror("Error", f"Error al acceder a la bóveda: {str(e)}")
-    
-    def sync_and_login(self):
-        """Sincroniza con la nube antes de hacer login"""
+
+    def register(self):
+        """Registra un nuevo usuario y accede a la bóveda."""
+        username = self.username_entry.get().strip()
         password = self.password_entry.get()
-        
-        if not password:
-            messagebox.showerror("Error", "Por favor ingresa tu contraseña maestra")
+
+        if not self.validate_credentials(username, password):
             return
-        
-        # Mostrar diálogo de progreso
-        progress_dialog = ctk.CTkToplevel(self.root)
-        progress_dialog.title("Sincronizando...")
-        progress_dialog.geometry("300x150")
-        progress_dialog.transient(self.root)
-        progress_dialog.grab_set()
-        
-        progress_label = ctk.CTkLabel(progress_dialog, text="Sincronizando con la nube...", 
-                                     font=ctk.CTkFont(size=14))
-        progress_label.pack(pady=30)
-        
-        progress_bar = ctk.CTkProgressBar(progress_dialog, width=250)
-        progress_bar.pack(pady=10)
-        progress_bar.set(0.5)
-        
-        def sync_thread():
-            try:
-                success = self.cloud_sync.sync_vault(self.vault_file)
-                progress_dialog.destroy()
-                
-                if success:
-                    messagebox.showinfo("Éxito", "Sincronización completada")
-                else:
-                    messagebox.showwarning("Advertencia", "No se pudo sincronizar, usando versión local")
-                
-                self.vault_data, self.vault_key = load_or_create_vault(self.vault_file, password)
-                self.master_password = password
-                self.update_activity()
-                self.setup_main_screen()
-                
-            except Exception as e:
-                progress_dialog.destroy()
-                messagebox.showerror("Error", f"Error durante la sincronización: {str(e)}")
-        
-        threading.Thread(target=sync_thread, daemon=True).start()
-        
+
+        db_file = "users.json"
+        db = load_user_db(db_file)
+        if username in db:
+            messagebox.showerror("Error", "El usuario ya existe.")
+            return
+
+        try:
+            create_user(username, password, db_file)
+            messagebox.showinfo("Éxito", "Usuario registrado correctamente.")
+            self.vault_file = f"{username}_vault.json"
+            self.master_password = password
+            self.username = username
+            self.vault_data, self.vault_key = load_or_create_vault(
+                self.vault_file, self.master_password
+            )
+            self.update_activity()
+            self.setup_main_screen()
+        except ValueError as exc:
+            messagebox.showerror("Error", f"No se pudo registrar: {exc}")
+
     def setup_main_screen(self):
         """Configura la pantalla principal del gestor"""
         # Limpiar ventana
@@ -745,10 +784,12 @@ class PasswordVaultComplete:
         if self.vault_data is not None:
             if messagebox.askyesno("Sincronizar", "¿Deseas sincronizar tus cambios con la nube antes de salir?"):
                 self.manual_sync()
-        
+
         self.vault_data = None
         self.vault_key = None
         self.master_password = None
+        self.username = None
+        self.vault_file = "password_vault_complete.json"
         self.selected_entry = None
         self.setup_login_screen()
         


### PR DESCRIPTION
## Summary
- replace sync-and-login with standalone register button
- remove registration prompt from login
- create dedicated user registration handler
- validate username and password fields before login or registration

## Testing
- `python -m py_compile vault_complete.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b721137a7c83239b3ca34129e3478e